### PR TITLE
adjust script for idempotent 'nix run'

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,6 +20,26 @@
         "type": "github"
       }
     },
+    "nh": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1754913455,
+        "narHash": "sha256-pnq15m/78lyeGNOxNSS/p2ndAN9bBUgcf4+D+pTm5ps=",
+        "owner": "nix-community",
+        "repo": "nh",
+        "rev": "dad5d56c9c1d4e1f04857d56b629b99e8b8eab7c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nh",
+        "type": "github"
+      }
+    },
     "nix-darwin": {
       "inputs": {
         "nixpkgs": [
@@ -59,6 +79,7 @@
     "root": {
       "inputs": {
         "home-manager": "home-manager",
+        "nh": "nh",
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs",
         "sops-nix": "sops-nix"

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
     };
   };
 
-  outputs = { self, nix-darwin, nixpkgs, home-manager, sops-nix, inputs }:
+  outputs = { self, nix-darwin, nixpkgs, home-manager, sops-nix }:
     let
       # Define darwinConfigurations first
       darwinConfigurations = {

--- a/flake.nix
+++ b/flake.nix
@@ -13,9 +13,13 @@
       url = "github:Mic92/sops-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    nh = {
+      url = "github:nix-community/nh";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nix-darwin, nixpkgs, home-manager, sops-nix }:
+  outputs = { self, nix-darwin, nixpkgs, home-manager, sops-nix, nh }:
     let
       # Define darwinConfigurations first
       darwinConfigurations = {
@@ -66,7 +70,7 @@
             overlays = [
               # Add nh to the package set
               (final: prev: {
-                nh = inputs.nh.packages.aarch64-darwin.default;
+                nh = nh.packages.aarch64-darwin.default;
               })
             ];
           };

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
     };
   };
 
-  outputs = { self, nix-darwin, nixpkgs, home-manager, sops-nix }:
+  outputs = { self, nix-darwin, nixpkgs, home-manager, sops-nix, inputs }:
     let
       # Define darwinConfigurations first
       darwinConfigurations = {
@@ -61,17 +61,25 @@
       # Define packages for `nix build`
       packages.aarch64-darwin.default =
         let
-          pkgs = import nixpkgs { system = "aarch64-darwin"; };
+          pkgs = import nixpkgs { 
+            system = "aarch64-darwin";
+            overlays = [
+              # Add nh to the package set
+              (final: prev: {
+                nh = inputs.nh.packages.aarch64-darwin.default;
+              })
+            ];
+          };
         in
         pkgs.writeShellScriptBin "apply-configurations" ''
           USERNAME=$(whoami)
 
           if [ "$USERNAME" = "dminca" ]; then
-            sudo ${darwinConfigurations.ZionProxy.config.system.build.toplevel}/sw/bin/darwin-rebuild switch --flake . &&
-            ${homeConfigurations.dminca.activationPackage}/activate
+            ${pkgs.nh}/bin/nh os switch --hostname ZionProxy . &&
+            ${pkgs.nh}/bin/nh home switch --configuration dminca .
           elif [ "$USERNAME" = "mida4001" ]; then
-            sudo ${darwinConfigurations.MLGERHL6W4P2RXH.config.system.build.toplevel}/sw/bin/darwin-rebuild switch --flake . &&
-            ${homeConfigurations.mida4001.activationPackage}/activate
+            ${pkgs.nh}/bin/nh os switch --hostname MLGERHL6W4P2RXH . &&
+            ${pkgs.nh}/bin/nh home switch --configuration mida4001 .
           else
             echo "Unknown user: $USERNAME"
             exit 1

--- a/hosts/common/system.nix
+++ b/hosts/common/system.nix
@@ -6,6 +6,7 @@
 {
   environment.systemPackages = with pkgs; [
     neovim
+    nh
   ];
   nix.settings.experimental-features = "nix-command flakes";
   nix.enable = false;

--- a/hosts/common/system.nix
+++ b/hosts/common/system.nix
@@ -6,7 +6,6 @@
 {
   environment.systemPackages = with pkgs; [
     neovim
-    nh
   ];
   nix.settings.experimental-features = "nix-command flakes";
   nix.enable = false;


### PR DESCRIPTION
- instead of using the script to call `darwin-rebuilt` and `home-manager` use [nh](https://github.com/nix-community/nh) which has both tooling embedded
- credits to https://matrix.to/#/!SgYlXivkogarTVcnZO:nixos.org/$pfqUFCE1mRqzlty_lJoov6y8q-xMgaAkX2nGvlolGoI?via=nixos.org&via=matrix.org&via=tchncs.de